### PR TITLE
remove leading slash in route

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -34,6 +34,9 @@ function Proxy(server, webSettings, adapter, instanceSettings, app) {
     if (this.config.errorTimeout < 1000) this.config.errorTimeout = 1000;
 
     this.config.route = this.config.route || (that.namespace + '/');
+    // remove leading slash
+    if (this.config.route.charAt(0) == '/') this.config.route = this.config.route.substr(1);
+
     var mime = require('mime');
 
     this.interval = setInterval(function () {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -35,7 +35,9 @@ function Proxy(server, webSettings, adapter, instanceSettings, app) {
 
     this.config.route = this.config.route || (that.namespace + '/');
     // remove leading slash
-    if (this.config.route.charAt(0) == '/') this.config.route = this.config.route.substr(1);
+    if (this.config.route[0] === '/') {
+        this.config.route = this.config.route.substr(1);
+    }
 
     var mime = require('mime');
 


### PR DESCRIPTION
I tried to setup a proxy to a site that required access on root level.
Configuring an empty route results in the default "proxy.0/" but setting up as "/" requires access with double slash (http://<address>//<path>/).

With this change a proxy with route "/" can be configured and accessed with http://<address>/<path>/.