### PR TITLE
Fix mime type lookup

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -185,7 +185,7 @@ function Proxy(server, webSettings, adapter, instanceSettings, app) {
                             res.status(500).send('[proxy] Cannot read file: ' + e);
                             return;
                         }
-                        res.contentType(mime.getType(path.extname(fileName).substring(1)));
+                        res.contentType(mime.lookup(path.extname(fileName).substring(1)));
                         res.status(200).send(data);
                     }
                 } else {


### PR DESCRIPTION
Don't know if the mime package changed in the meantime, but I just installed the proxy adapter and it returned an error when delivering a local file. I digged into it and found the function is named "lookup" instead of "getType".